### PR TITLE
Ensure only one instance of the openai client exists

### DIFF
--- a/src/routes/api/chat-completion/+server.ts
+++ b/src/routes/api/chat-completion/+server.ts
@@ -6,6 +6,7 @@ let openai = undefined;
 
 /** @type {import('./$types').RequestHandler} */
 export async function POST(event: RequestEvent) {
+    // This load the openai client at runtime to prevent a compile time dependency on  the environment variables
     if (openai === undefined) {
         openai = new OpenAI({
             apiKey: env.OPENAI_API_KEY,

--- a/src/routes/api/chat-completion/+server.ts
+++ b/src/routes/api/chat-completion/+server.ts
@@ -6,7 +6,7 @@ let openai = new OpenAI();
 
 /** @type {import('./$types').RequestHandler} */
 export async function POST(event: RequestEvent) {
-    // This set the openai client values at runtime to prevent a compile time dependency on the environment variables
+    // This sets the openai client values at runtime to prevent a compile time dependency on the environment variables
     openai.apiKey = env.OPENAI_API_KEY;
     openai.baseURL = env.OPENAI_API_HOST;
 

--- a/src/routes/api/chat-completion/+server.ts
+++ b/src/routes/api/chat-completion/+server.ts
@@ -2,13 +2,17 @@ import OpenAI from 'openai';
 import type { RequestEvent } from '@sveltejs/kit';
 import {env} from "$env/dynamic/private";
 
-let openai = new OpenAI();
+let openai = undefined;
 
 /** @type {import('./$types').RequestHandler} */
 export async function POST(event: RequestEvent) {
-    // This sets the openai client values at runtime to prevent a compile time dependency on the environment variables
-    openai.apiKey = env.OPENAI_API_KEY;
-    openai.baseURL = env.OPENAI_API_HOST;
+    // This load the openai client at runtime to prevent a compile time dependency on the environment variables
+    if (openai === undefined) {
+        openai = new OpenAI({
+            apiKey: env.OPENAI_API_KEY,
+            baseURL: env.OPENAI_API_HOST
+        });
+    }
 
     try {
         const data = await event.request.json()

--- a/src/routes/api/chat-completion/+server.ts
+++ b/src/routes/api/chat-completion/+server.ts
@@ -6,7 +6,7 @@ let openai = undefined;
 
 /** @type {import('./$types').RequestHandler} */
 export async function POST(event: RequestEvent) {
-    // This load the openai client at runtime to prevent a compile time dependency on  the environment variables
+    // This load the openai client at runtime to prevent a compile time dependency on the environment variables
     if (openai === undefined) {
         openai = new OpenAI({
             apiKey: env.OPENAI_API_KEY,

--- a/src/routes/api/chat-completion/+server.ts
+++ b/src/routes/api/chat-completion/+server.ts
@@ -2,12 +2,16 @@ import OpenAI from 'openai';
 import type { RequestEvent } from '@sveltejs/kit';
 import {env} from "$env/dynamic/private";
 
+let openai = undefined;
+
 /** @type {import('./$types').RequestHandler} */
 export async function POST(event: RequestEvent) {
-    const openai = new OpenAI({
-        apiKey: env.OPENAI_API_KEY,
-        baseURL: env.OPENAI_API_HOST
-    });
+    if (openai === undefined) {
+        openai = new OpenAI({
+            apiKey: env.OPENAI_API_KEY,
+            baseURL: env.OPENAI_API_HOST
+        });
+    }
 
     try {
         const data = await event.request.json()

--- a/src/routes/api/chat-completion/+server.ts
+++ b/src/routes/api/chat-completion/+server.ts
@@ -2,17 +2,13 @@ import OpenAI from 'openai';
 import type { RequestEvent } from '@sveltejs/kit';
 import {env} from "$env/dynamic/private";
 
-let openai = undefined;
+let openai = new OpenAI();
 
 /** @type {import('./$types').RequestHandler} */
 export async function POST(event: RequestEvent) {
-    // This load the openai client at runtime to prevent a compile time dependency on the environment variables
-    if (openai === undefined) {
-        openai = new OpenAI({
-            apiKey: env.OPENAI_API_KEY,
-            baseURL: env.OPENAI_API_HOST
-        });
-    }
+    // This set the openai client values at runtime to prevent a compile time dependency on the environment variables
+    openai.apiKey = env.OPENAI_API_KEY;
+    openai.baseURL = env.OPENAI_API_HOST;
 
     try {
         const data = await event.request.json()

--- a/src/routes/api/models/+server.ts
+++ b/src/routes/api/models/+server.ts
@@ -2,13 +2,17 @@ import type { RequestEvent } from '@sveltejs/kit';
 import OpenAI from 'openai';
 import {env} from "$env/dynamic/private";
 
-let openai = new OpenAI();
+let openai = undefined;
 
 /** @type {import('./$types').RequestHandler} */
 export async function GET(event: RequestEvent) {
-    // This sets the openai client values at runtime to prevent a compile time dependency on the environment variables
-    openai.apiKey = env.OPENAI_API_KEY;
-    openai.baseURL = env.OPENAI_API_HOST;
+    // This loads the openai client at runtime to prevent a compile time dependency on the environment variables
+    if (openai === undefined) {
+        openai = new OpenAI({
+            apiKey: env.OPENAI_API_KEY,
+            baseURL: env.OPENAI_API_HOST
+        });
+    }
 
     try {
         // Make a request to OpenAI's model API

--- a/src/routes/api/models/+server.ts
+++ b/src/routes/api/models/+server.ts
@@ -2,17 +2,13 @@ import type { RequestEvent } from '@sveltejs/kit';
 import OpenAI from 'openai';
 import {env} from "$env/dynamic/private";
 
-let openai = undefined;
+let openai = new OpenAI();
 
 /** @type {import('./$types').RequestHandler} */
 export async function GET(event: RequestEvent) {
-    // This loads the openai client at runtime to prevent a compile time dependency on the environment variables
-    if (openai === undefined) {
-        openai = new OpenAI({
-            apiKey: env.OPENAI_API_KEY,
-            baseURL: env.OPENAI_API_HOST
-        });
-    }
+    // This set the openai client values at runtime to prevent a compile time dependency on the environment variables
+    openai.apiKey = env.OPENAI_API_KEY;
+    openai.baseURL = env.OPENAI_API_HOST;
 
     try {
         // Make a request to OpenAI's model API

--- a/src/routes/api/models/+server.ts
+++ b/src/routes/api/models/+server.ts
@@ -6,6 +6,7 @@ let openai = undefined;
 
 /** @type {import('./$types').RequestHandler} */
 export async function GET(event: RequestEvent) {
+    // This load the openai client at runtime to prevent a compile time dependency on  the environment variables
     if (openai === undefined) {
         openai = new OpenAI({
             apiKey: env.OPENAI_API_KEY,

--- a/src/routes/api/models/+server.ts
+++ b/src/routes/api/models/+server.ts
@@ -6,7 +6,7 @@ let openai = undefined;
 
 /** @type {import('./$types').RequestHandler} */
 export async function GET(event: RequestEvent) {
-    // This load the openai client at runtime to prevent a compile time dependency on  the environment variables
+    // This loads the openai client at runtime to prevent a compile time dependency on the environment variables
     if (openai === undefined) {
         openai = new OpenAI({
             apiKey: env.OPENAI_API_KEY,

--- a/src/routes/api/models/+server.ts
+++ b/src/routes/api/models/+server.ts
@@ -6,7 +6,7 @@ let openai = new OpenAI();
 
 /** @type {import('./$types').RequestHandler} */
 export async function GET(event: RequestEvent) {
-    // This set the openai client values at runtime to prevent a compile time dependency on the environment variables
+    // This sets the openai client values at runtime to prevent a compile time dependency on the environment variables
     openai.apiKey = env.OPENAI_API_KEY;
     openai.baseURL = env.OPENAI_API_HOST;
 

--- a/src/routes/api/models/+server.ts
+++ b/src/routes/api/models/+server.ts
@@ -2,12 +2,16 @@ import type { RequestEvent } from '@sveltejs/kit';
 import OpenAI from 'openai';
 import {env} from "$env/dynamic/private";
 
+let openai = undefined;
+
 /** @type {import('./$types').RequestHandler} */
 export async function GET(event: RequestEvent) {
-    const openai = new OpenAI({
-        apiKey: env.OPENAI_API_KEY,
-        baseURL: env.OPENAI_API_HOST
-    });
+    if (openai === undefined) {
+        openai = new OpenAI({
+            apiKey: env.OPENAI_API_KEY,
+            baseURL: env.OPENAI_API_HOST
+        });
+    }
 
     try {
         // Make a request to OpenAI's model API


### PR DESCRIPTION
Creates a single instance of the openai client while ensuring that its created at runtime