### PR TITLE
Adds switch to last conversation upon delete

### DIFF
--- a/src/routes/chat/+page.svelte
+++ b/src/routes/chat/+page.svelte
@@ -313,8 +313,17 @@
         }
     }
 
+    function switchToLastConversation() {
+        $currentConversation = $conversations[$conversations.length - 1].id
+    }
+
     function removeConversation(id) {
         conversations.update((n) => n.filter((c) => c.id !== id));
+
+        let isCurrentConversationDeleted = $conversations.length > 0 && id == $currentConversation;
+        if (isCurrentConversationDeleted) {
+            switchToLastConversation();
+        }
     }
 
     let editingConversationIndex = -1;


### PR DESCRIPTION
When a conversation is deleted, it will switch to the last created conversation. This fixes an error where the selected conversation id ceases to exist but the conversations are not empty, preventing a new conversation from being created.