### PR TITLE
Check if concurrentRequests var is undefined

### DIFF
--- a/src/lib/interfaces/file_lock.ts
+++ b/src/lib/interfaces/file_lock.ts
@@ -10,7 +10,7 @@ export class FileLock {
 
     constructor(concurrentRequests: string, folderName: string = 'lock_files') {
         this.deleteOldLockFile()
-        this.concurrentRequests = concurrentRequests.toLowerCase() == "true";
+        this.concurrentRequests = concurrentRequests !== undefined && concurrentRequests.toLowerCase() == "true";
         this.basePath = path.join(os.tmpdir(), folderName);
         if (!fs.existsSync(this.basePath)) {
             fs.mkdirSync(this.basePath);


### PR DESCRIPTION
Without this check if you do not have an environment variable set on your host for `CONCURRENT_REQUESTS` we get an error for trying to dereference an undefined object.